### PR TITLE
Bring back livequery with v1.1.1

### DIFF
--- a/plugins/Quotes/js/quotes.js
+++ b/plugins/Quotes/js/quotes.js
@@ -3,12 +3,11 @@ function Gdn_Quotes() {
    this.InsertMode = 'default';
    this.Editors = [];
    this.EditorID = 1;
-   var jBody = $('body');
 
    Gdn_Quotes.prototype.Prepare = function() {
 
       // Attach quote event to each Quote button, and return false to prevent link follow
-      jBody.on('click', 'a.ReactButton.Quote', jQuery.proxy(function(event){
+      $('a.ReactButton.Quote').livequery('click', jQuery.proxy(function(event){
          var QuoteLink = jQuery(event.target).closest('a');
          var ObjectID = QuoteLink.attr('href').split('/').pop();
          this.Quote(ObjectID, QuoteLink);
@@ -23,18 +22,18 @@ function Gdn_Quotes() {
 
       // Follow edit clicks
       var Quotes = this;
-      jBody.on('DOMNodeInserted','textarea.TextBox', function(){
+      jQuery('textarea.TextBox').livequery(function(){
          Quotes.EditorStack(this);
       }, function(){
          Quotes.EditorStack(this, true);
       });
 
       // Determine what mode we're in (default, cleditor... ?)
-      jBody.on('DOMNodeInserted', 'div.cleditorMain', function(){
+      jQuery('div.cleditorMain').livequery(function(){
             Quotes.SetInsertMode('cleditor', this);
       });
 
-      jBody.on('DOMNodeInserted', 'cke_Form_Body', function(){
+      jQuery('#cke_Form_Body').livequery(function(){
          Quotes.SetInsertMode('ckeditor', this);
       });
 
@@ -43,7 +42,9 @@ function Gdn_Quotes() {
       if (QuoteFoldingLevel != 'None') {
          QuoteFoldingLevel = parseInt(QuoteFoldingLevel) + 1;
          var MaxFoldingLevel = 6;
-         jBody.on('DOMNodeInserted', '.Comment .Message', function(){
+         jQuery('.Comment .Message').livequery(function(){
+
+
             // Find the closest child quote
             var PetQuote = jQuery(this).children('.UserQuote');
             if (!PetQuote.length) return;
@@ -52,7 +53,7 @@ function Gdn_Quotes() {
 
          });
 
-         jBody.on('click', 'a.QuoteFolding', function(){
+         jQuery('a.QuoteFolding').livequery('click', function(){
             var QuoteTarget = jQuery(this).closest('.QuoteText').children('.UserQuote');
             QuoteTarget = jQuery(QuoteTarget);
             QuoteTarget.toggle();

--- a/plugins/ckeditor/default.php
+++ b/plugins/ckeditor/default.php
@@ -83,9 +83,11 @@ class ckeditorPlugin extends Gdn_Plugin
 </style>
 <script type="text/javascript">
 	jQuery(document).ready( function($) {
-			$("textarea.BodyBox").ckeditor({
+		$("textarea.BodyBox").livequery( function( ) {
+			$(this).ckeditor({
 				extraAllowedContent: 'blockquote[rel](Quote)'
 			});
+		});
 	});
 </script>
 EOT


### PR DESCRIPTION
This PR will require the approval of

https://git.dazcorp.com/DAZ3D/Farnsworth/pull/313

Once livequery 1.1.1 is included in Farnsworth, we can go back to calling livequery calls.